### PR TITLE
N8N-1 Add missing jsonwebtoken types for google enhanced cloud storage node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@swc/core": "~1.3.85",
         "@swc/helpers": "~0.5.2",
         "@types/jest": "^29.5.12",
+        "@types/jsonwebtoken": "^9.0.6",
         "@types/node": "18.19.14",
         "@typescript-eslint/eslint-plugin": "7.7.0",
         "@typescript-eslint/parser": "7.7.0",
@@ -8747,6 +8748,15 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
+    },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.6.tgz",
+      "integrity": "sha512-/5hndP5dCjloafCXns6SZyESp3Ldq7YjH3zwzwczYnjxIT0Fqzk5ROSYVGfFyczIue7IUEj8hkvLbPoLQ18vQw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/linkify-it": {
       "version": "3.0.5",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@swc/core": "~1.3.85",
     "@swc/helpers": "~0.5.2",
     "@types/jest": "^29.5.12",
+    "@types/jsonwebtoken": "^9.0.6",
     "@types/node": "18.19.14",
     "@typescript-eslint/eslint-plugin": "7.7.0",
     "@typescript-eslint/parser": "7.7.0",


### PR DESCRIPTION
This pull request will add missing types for the jsonwebtoken dependency for the google enhanced cloud storage node.

Attention: The failing test pipeline is unrelated to this change and will be fixed when the follow-up pull requests are merged.