### PR TITLE
N8N-1 fix error handling for continue on fail

### DIFF
--- a/nodes/google-enhanced/src/nodes/GoogleCloudStorageEnhanced/GoogleCloudStorageEnhanced.node.spec.ts
+++ b/nodes/google-enhanced/src/nodes/GoogleCloudStorageEnhanced/GoogleCloudStorageEnhanced.node.spec.ts
@@ -1399,7 +1399,9 @@ describe('GoogleCloudStorageEnhanced', () => {
 
     expect(
       googleCloudStorageEnhanced.execute.call(executeFunctions),
-    ).resolves.toEqual([[{ error: '__error_message__', json: {} }]]);
+    ).resolves.toEqual([
+      [{ json: { error: '__error_message__' }, pairedItem: { item: 0 } }],
+    ]);
 
     expect(googleApiRequest).toHaveBeenCalledWith(
       'GET',

--- a/nodes/google-enhanced/src/nodes/GoogleCloudStorageEnhanced/GoogleCloudStorageEnhanced.node.ts
+++ b/nodes/google-enhanced/src/nodes/GoogleCloudStorageEnhanced/GoogleCloudStorageEnhanced.node.ts
@@ -8,6 +8,7 @@ import {
 } from 'n8n-nodes-base/dist/nodes/Google/CloudStorage/ObjectDescription';
 import {
   BINARY_ENCODING,
+  NodeApiError,
   type IDataObject,
   type IExecuteFunctions,
   type INodeExecutionData,
@@ -532,9 +533,12 @@ export class GoogleCloudStorageEnhanced implements INodeType {
         );
 
         returnData.push(...executionData);
-      } catch (error: any) {
+      } catch (error: unknown) {
         if (this.continueOnFail()) {
-          returnData.push({ error: error.message, json: {} });
+          returnData.push({
+            json: { error: (error as NodeApiError).message },
+            pairedItem: { item },
+          });
           continue;
         }
 

--- a/nodes/moco/src/nodes/Moco/Moco.node.spec.ts
+++ b/nodes/moco/src/nodes/Moco/Moco.node.spec.ts
@@ -1760,7 +1760,7 @@ describe('Moco', () => {
     executeFunctions.continueOnFail.mockReturnValue(true);
 
     expect(moco.execute.call(executeFunctions)).resolves.toEqual([
-      [{ error: '__error_message__', json: {} }],
+      [{ json: { error: '__error_message__' }, pairedItem: { item: 0 } }],
     ]);
 
     expect(mockedMocoApiRequest).toHaveBeenCalledWith(

--- a/nodes/moco/src/nodes/Moco/Moco.node.ts
+++ b/nodes/moco/src/nodes/Moco/Moco.node.ts
@@ -6,6 +6,7 @@ import type {
   INodePropertyOptions,
   INodeType,
   INodeTypeDescription,
+  NodeApiError,
 } from 'n8n-workflow';
 import type {
   Activity,
@@ -682,9 +683,12 @@ export class Moco implements INodeType {
         );
 
         returnData.push(...executionData);
-      } catch (error: any) {
+      } catch (error: unknown) {
         if (this.continueOnFail()) {
-          returnData.push({ error: error.message, json: {} });
+          returnData.push({
+            json: { error: (error as NodeApiError).message },
+            pairedItem: { item },
+          });
           continue;
         }
 


### PR DESCRIPTION
Attention: this pull request is based on https://github.com/skriptfabrik/n8n-nodes/pull/59.

This pull request will fix the return data when handling the `continueOnFail` case based on the implementations in the existing n8n-base-nodes.