### PR TITLE
N8N-3 Replace unmaintained action for retrieving tag information

### DIFF
--- a/.github/workflows/publish-package.yaml
+++ b/.github/workflows/publish-package.yaml
@@ -38,7 +38,7 @@ jobs:
         run: npm ci
 
       - name: Get tag
-        uses: little-core-labs/get-tag@v3.0.2
+        uses: olegtarasov/get-tag@v2.1.3
         id: tag
         with:
           tagRegex: '(?<name>.*)-(?<version>.*)'


### PR DESCRIPTION
This pull request will switch the get-tag action back to the original one, as the currently used one seems to be unmaintained.

The warning regarding "set-output" from the workflow execution: https://github.com/skriptfabrik/n8n-nodes/actions/runs/8965974723 will still be present as the latest version of the action will still use this deprecated instruction.