### PR TITLE
N8N-2 Update NX project configuration

### DIFF
--- a/nodes/barcode/project.json
+++ b/nodes/barcode/project.json
@@ -1,7 +1,7 @@
 {
   "name": "n8n-nodes-barcode",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
-  "sourceRoot": "nodes/barcode-node/src",
+  "sourceRoot": "nodes/barcode/src",
   "projectType": "library",
   "targets": {
     "build": {

--- a/nodes/channable/project.json
+++ b/nodes/channable/project.json
@@ -9,9 +9,8 @@
       "outputs": ["{options.outputPath}"],
       "options": {
         "outputPath": "dist/nodes/channable",
-        "tsConfig": "nodes/channable/tsconfig.lib.json",
-        "packageJson": "nodes/channable/package.json",
         "main": "nodes/channable/src/index.ts",
+        "tsConfig": "nodes/channable/tsconfig.lib.json",
         "assets": [
           "nodes/channable/src/nodes/*/icons/*",
           "nodes/channable/*.md"

--- a/nodes/clockify-enhanced/project.json
+++ b/nodes/clockify-enhanced/project.json
@@ -9,9 +9,8 @@
       "outputs": ["{options.outputPath}"],
       "options": {
         "outputPath": "dist/nodes/clockify-enhanced",
-        "tsConfig": "nodes/clockify-enhanced/tsconfig.lib.json",
-        "packageJson": "nodes/clockify-enhanced/package.json",
         "main": "nodes/clockify-enhanced/src/index.ts",
+        "tsConfig": "nodes/clockify-enhanced/tsconfig.lib.json",
         "assets": [
           "nodes/clockify-enhanced/src/nodes/*/icons/*.svg",
           "nodes/clockify-enhanced/src/nodes/*/*.json",

--- a/nodes/cronhooks/project.json
+++ b/nodes/cronhooks/project.json
@@ -9,9 +9,8 @@
       "outputs": ["{options.outputPath}"],
       "options": {
         "outputPath": "dist/nodes/cronhooks",
-        "tsConfig": "nodes/cronhooks/tsconfig.lib.json",
-        "packageJson": "nodes/cronhooks/package.json",
         "main": "nodes/cronhooks/src/index.ts",
+        "tsConfig": "nodes/cronhooks/tsconfig.lib.json",
         "assets": [
           "nodes/cronhooks/src/nodes/*/icons/*.svg",
           "nodes/cronhooks/src/nodes/*/*.json",

--- a/nodes/fulfillmenttools/project.json
+++ b/nodes/fulfillmenttools/project.json
@@ -9,9 +9,8 @@
       "outputs": ["{options.outputPath}"],
       "options": {
         "outputPath": "dist/nodes/fulfillmenttools",
-        "tsConfig": "nodes/fulfillmenttools/tsconfig.lib.json",
-        "packageJson": "nodes/fulfillmenttools/package.json",
         "main": "nodes/fulfillmenttools/src/index.ts",
+        "tsConfig": "nodes/fulfillmenttools/tsconfig.lib.json",
         "assets": [
           "nodes/fulfillmenttools/src/nodes/*/icons/*.svg",
           "nodes/fulfillmenttools/src/nodes/*/*.json",

--- a/nodes/google-enhanced/project.json
+++ b/nodes/google-enhanced/project.json
@@ -9,9 +9,8 @@
       "outputs": ["{options.outputPath}"],
       "options": {
         "outputPath": "dist/nodes/google-enhanced",
-        "tsConfig": "nodes/google-enhanced/tsconfig.lib.json",
-        "packageJson": "nodes/google-enhanced/package.json",
         "main": "nodes/google-enhanced/src/index.ts",
+        "tsConfig": "nodes/google-enhanced/tsconfig.lib.json",
         "assets": [
           "nodes/google-enhanced/src/nodes/*/*.svg",
           "nodes/google-enhanced/src/nodes/*/*.json",

--- a/nodes/kaufland-marketplace/project.json
+++ b/nodes/kaufland-marketplace/project.json
@@ -9,9 +9,8 @@
       "outputs": ["{options.outputPath}"],
       "options": {
         "outputPath": "dist/nodes/kaufland-marketplace",
-        "tsConfig": "nodes/kaufland-marketplace/tsconfig.lib.json",
-        "packageJson": "nodes/kaufland-marketplace/package.json",
         "main": "nodes/kaufland-marketplace/src/index.ts",
+        "tsConfig": "nodes/kaufland-marketplace/tsconfig.lib.json",
         "assets": [
           "nodes/kaufland-marketplace/src/nodes/*/icons/*",
           "nodes/kaufland-marketplace/*.md"

--- a/nodes/moco/project.json
+++ b/nodes/moco/project.json
@@ -9,9 +9,8 @@
       "outputs": ["{options.outputPath}"],
       "options": {
         "outputPath": "dist/nodes/moco",
-        "tsConfig": "nodes/moco/tsconfig.lib.json",
-        "packageJson": "nodes/moco/package.json",
         "main": "nodes/moco/src/index.ts",
+        "tsConfig": "nodes/moco/tsconfig.lib.json",
         "assets": [
           "nodes/moco/src/nodes/*/*.svg",
           "nodes/moco/src/nodes/*/*.json",

--- a/nodes/otto-market/project.json
+++ b/nodes/otto-market/project.json
@@ -9,9 +9,8 @@
       "outputs": ["{options.outputPath}"],
       "options": {
         "outputPath": "dist/nodes/otto-market",
-        "tsConfig": "nodes/otto-market/tsconfig.lib.json",
-        "packageJson": "nodes/otto-market/package.json",
         "main": "nodes/otto-market/src/index.ts",
+        "tsConfig": "nodes/otto-market/tsconfig.lib.json",
         "assets": [
           "nodes/otto-market/src/nodes/*/icons/*",
           "nodes/otto-market/*.md"

--- a/nodes/sentry-io-enhanced/project.json
+++ b/nodes/sentry-io-enhanced/project.json
@@ -9,9 +9,8 @@
       "outputs": ["{options.outputPath}"],
       "options": {
         "outputPath": "dist/nodes/sentry-io-enhanced",
-        "tsConfig": "nodes/sentry-io-enhanced/tsconfig.lib.json",
-        "packageJson": "nodes/sentry-io-enhanced/package.json",
         "main": "nodes/sentry-io-enhanced/src/index.ts",
+        "tsConfig": "nodes/sentry-io-enhanced/tsconfig.lib.json",
         "assets": [
           "nodes/sentry-io-enhanced/src/nodes/*/icons/*.svg",
           "nodes/sentry-io-enhanced/src/nodes/*/*.json",


### PR DESCRIPTION
This pull request will remove the obsolete build option `packageJson` from the `@nx/js:tsc` build executer.

It will also fix the `sourceRoot` configuration for the barcode node.