### PR TITLE
N8N-2 Extend Sentry.io node with user definable tags and extra

### DIFF
--- a/nodes/sentry-io-enhanced/package.json
+++ b/nodes/sentry-io-enhanced/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skriptfabrik/n8n-nodes-sentry-io-enhanced",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Enhanced Sentry.io community nodes for n8n",
   "keywords": [
     "Sentry",

--- a/nodes/sentry-io-enhanced/src/nodes/SentryIoEnhanced/GenericFunctions.spec.ts
+++ b/nodes/sentry-io-enhanced/src/nodes/SentryIoEnhanced/GenericFunctions.spec.ts
@@ -1,0 +1,32 @@
+import { mockClear, mockDeep } from 'jest-mock-extended';
+
+import type { IExecuteFunctions } from 'n8n-workflow';
+
+import { getOptionsFromNodeParameter } from './GenericFunctions';
+
+describe('GenericFunctions', () => {
+  describe('getOptionsFromNodeParameter', () => {
+    const executeFunctions = mockDeep<IExecuteFunctions>();
+
+    afterEach(() => {
+      mockClear(executeFunctions);
+    });
+
+    it('should return an object with the key as the key and the value as the value', () => {
+      executeFunctions.getNodeParameter
+        .calledWith('tags.values', 0, expect.arrayContaining([]))
+        .mockReturnValue([
+          {
+            key: '_key_',
+            value: '_value_',
+          },
+        ]);
+
+      expect(
+        getOptionsFromNodeParameter.call(executeFunctions, 'tags.values', 0),
+      ).toEqual({
+        _key_: '_value_',
+      });
+    });
+  });
+});

--- a/nodes/sentry-io-enhanced/src/nodes/SentryIoEnhanced/GenericFunctions.ts
+++ b/nodes/sentry-io-enhanced/src/nodes/SentryIoEnhanced/GenericFunctions.ts
@@ -1,0 +1,26 @@
+import { IExecuteFunctions, NodeParameterValue } from 'n8n-workflow';
+
+export function getOptionsFromNodeParameter(
+  this: IExecuteFunctions,
+  parameterName: 'tags.values' | 'extra.values',
+  item: number,
+) {
+  const options = this.getNodeParameter(parameterName, item, []) as {
+    key: string;
+    value: NodeParameterValue | NodeParameterValue[] | object;
+  }[];
+
+  return options.reduce(
+    (
+      acc: {
+        [key: string]: NodeParameterValue | NodeParameterValue[] | object;
+      },
+      option,
+    ) => {
+      acc[option.key] = option.value;
+
+      return acc;
+    },
+    {},
+  );
+}


### PR DESCRIPTION
This pull request will extend the Sentry.io Enhanced node to be able to add additional `tags` and `extra` to a Sentry envelope.