### PR TITLE
chore: ignore n8n child dependencies (N8N-6)

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -23,6 +23,8 @@ updates:
     directory: '/'
     ignore:
       - dependency-name: '@types/*'
+      - dependency-name: 'n8n-nodes-base'
+      - dependency-name: 'n8n-workflow'
     reviewers:
       - 'skriptfabrik/npm-maintainers'
     schedule:
@@ -34,6 +36,8 @@ updates:
     directory: '/nodes/barcode'
     ignore:
       - dependency-name: '@types/*'
+      - dependency-name: 'n8n-nodes-base'
+      - dependency-name: 'n8n-workflow'
     reviewers:
       - 'skriptfabrik/npm-maintainers'
     schedule:
@@ -45,6 +49,8 @@ updates:
     directory: '/nodes/channable'
     ignore:
       - dependency-name: '@types/*'
+      - dependency-name: 'n8n-nodes-base'
+      - dependency-name: 'n8n-workflow'
     reviewers:
       - 'skriptfabrik/npm-maintainers'
     schedule:
@@ -56,6 +62,8 @@ updates:
     directory: '/nodes/clockify-enhanced'
     ignore:
       - dependency-name: '@types/*'
+      - dependency-name: 'n8n-nodes-base'
+      - dependency-name: 'n8n-workflow'
     reviewers:
       - 'skriptfabrik/npm-maintainers'
     schedule:
@@ -67,6 +75,8 @@ updates:
     directory: '/nodes/cronhooks'
     ignore:
       - dependency-name: '@types/*'
+      - dependency-name: 'n8n-nodes-base'
+      - dependency-name: 'n8n-workflow'
     reviewers:
       - 'skriptfabrik/npm-maintainers'
     schedule:
@@ -78,6 +88,8 @@ updates:
     directory: '/nodes/fulfillmenttools'
     ignore:
       - dependency-name: '@types/*'
+      - dependency-name: 'n8n-nodes-base'
+      - dependency-name: 'n8n-workflow'
     reviewers:
       - 'skriptfabrik/npm-maintainers'
     schedule:
@@ -89,6 +101,8 @@ updates:
     directory: '/nodes/google-enhanced'
     ignore:
       - dependency-name: '@types/*'
+      - dependency-name: 'n8n-nodes-base'
+      - dependency-name: 'n8n-workflow'
     reviewers:
       - 'skriptfabrik/npm-maintainers'
     schedule:
@@ -100,6 +114,8 @@ updates:
     directory: '/nodes/kaufland-marketplace'
     ignore:
       - dependency-name: '@types/*'
+      - dependency-name: 'n8n-nodes-base'
+      - dependency-name: 'n8n-workflow'
     reviewers:
       - 'skriptfabrik/npm-maintainers'
     schedule:
@@ -111,6 +127,8 @@ updates:
     directory: '/nodes/moco'
     ignore:
       - dependency-name: '@types/*'
+      - dependency-name: 'n8n-nodes-base'
+      - dependency-name: 'n8n-workflow'
     reviewers:
       - 'skriptfabrik/npm-maintainers'
     schedule:
@@ -122,6 +140,8 @@ updates:
     directory: '/nodes/otto-market'
     ignore:
       - dependency-name: '@types/*'
+      - dependency-name: 'n8n-nodes-base'
+      - dependency-name: 'n8n-workflow'
     reviewers:
       - 'skriptfabrik/npm-maintainers'
     schedule:
@@ -133,6 +153,8 @@ updates:
     directory: '/nodes/sentry-io-enhanced'
     ignore:
       - dependency-name: '@types/*'
+      - dependency-name: 'n8n-nodes-base'
+      - dependency-name: 'n8n-workflow'
     reviewers:
       - 'skriptfabrik/npm-maintainers'
     schedule:


### PR DESCRIPTION
This pull request will add the dependencies `n8n-nodes-base` and `n8n-workflow` to the dependabot ignore list as we need to manually pin them to the same version which is requested by n8n itself.