### PR TITLE
N8N-6 Ignore nx child dependencies

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -22,6 +22,7 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     ignore:
+      - dependency-name: '@nx/*'
       - dependency-name: '@types/*'
       - dependency-name: 'n8n-nodes-base'
       - dependency-name: 'n8n-workflow'


### PR DESCRIPTION
This pull request will add all '@nx' dependencies to the dependabot ignore list as they should be updated with the nx workspace by using the nx migrate command.