### PR TITLE
N8N-6 Group dependabot updated for @typescript-eslint dependencies

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -21,6 +21,10 @@ updates:
 
   - package-ecosystem: 'npm'
     directory: '/'
+    groups:
+      '@typescript-eslint':
+        patterns:
+          - '@typescript-eslint/*'
     ignore:
       - dependency-name: '@nx/*'
       - dependency-name: '@types/*'


### PR DESCRIPTION
This pull request will extend the dependabot configuration to group updated for the "@typescript-eslint" namespace.