### PR TITLE
N8N-11 Optimize and fix release workflow

### DIFF
--- a/.github/workflows/create-github-release.yaml
+++ b/.github/workflows/create-github-release.yaml
@@ -1,18 +1,11 @@
 name: Create GitHub Release
 
 on:
-  push:
-    tags:
-      - 'barcode-*'
-      - 'channable-*'
-      - 'clockify-enhanced-*'
-      - 'cronhooks-*'
-      - 'fulfillmenttools-*'
-      - 'google-enhanced-*'
-      - 'kaufland-marketplace-*'
-      - 'moco-*'
-      - 'otto-market-*'
-      - 'sentry-io-enhanced-*'
+  workflow_run:
+    workflows:
+      - Create Tag and Publish Package
+    types:
+      - completed
 
 permissions:
   contents: write
@@ -22,24 +15,29 @@ env:
 
 jobs:
   create-release:
-    name: Create GitHub release
+    name: Create GitHub Release
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.ref }}
+          fetch-tags: true
+
+      - name: Get latest tag
+        id: latest_tag
+        run: echo "tag=$(git describe --tags --abbrev=0 ${{ github.ref }})" >> "$GITHUB_OUTPUT"
 
       - name: Extract package name from tag
         id: extract_package
         # yamllint disable-line rule:line-length
-        run: echo "package=$(echo ${{ github.event.ref }} | sed -E 's#refs/tags/([^/]+)-[0-9]+\.[0-9]+\.[0-9]+.*#\1#')" >> "$GITHUB_OUTPUT"
+        run: echo "package=$(echo ${{ steps.latest_tag.outputs.tag }} | sed -E 's#([^/]+)-[0-9]+\.[0-9]+\.[0-9]+.*#\1#')" >> "$GITHUB_OUTPUT"
 
       - name: Extract version from tag
         id: extract_version
         # yamllint disable-line rule:line-length
-        run: echo "version=$(echo ${{ github.event.ref }} | sed -E 's#refs/tags/[^/]+-([0-9]+\.[0-9]+\.[0-9]+.*)#\1#')" >> "$GITHUB_OUTPUT"
+        run: echo "version=$(echo ${{ steps.latest_tag.outputs.tag }} | sed -E 's#[^/]+-([0-9]+\.[0-9]+\.[0-9]+.*)#\1#')" >> "$GITHUB_OUTPUT"
 
       - name: Extract Changelog
         id: changelog

--- a/.github/workflows/publish-package.yaml
+++ b/.github/workflows/publish-package.yaml
@@ -20,14 +20,14 @@ jobs:
     runs-on: ubuntu-latest
     # Only run this job if an actual publishing should be made
     if: ${{ (github.event.pull_request.merged == true) &&
-      (startsWith(github.event.pull_request.head.ref, 'release/')) &&
+      (startsWith(github.event.pull_request.head.ref, 'release-')) &&
       (contains(github.event.pull_request.labels.*.name, 'release')) }}
 
     steps:
       - name: Extract package from head ref
         id: extract_package
         # yamllint disable-line rule:line-length
-        run: echo "package=$(echo ${{ github.event.pull_request.head.ref }} | grep -oP '(?<=release/)[^@]+(?=@)')" >> "$GITHUB_OUTPUT"
+        run: echo "package=$(echo ${{ github.event.pull_request.head.ref }} | sed -E 's/release-(.*)@.*/\1/')" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -50,17 +50,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Create tag
-        run: |
-          npx nx release version \
-            --projects=${{ steps.extract_package.outputs.package }} \
-            --git-commit=false \
-            --git-tag=true
-
-      - name: Publish package
-        run: |
-          npx nx release publish \
-            --projects=${{ steps.extract_package.outputs.package }}
+      - name: Create tag and publish package
+        run: npx nx release --projects=${{ steps.extract_package.outputs.package }}
 
       - name: Push tags
         run: git push origin --follow-tags

--- a/.github/workflows/release-package.yaml
+++ b/.github/workflows/release-package.yaml
@@ -38,10 +38,27 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - name: Check on existing release branch
+        # yamllint disable rule:line-length
+        run: |
+          if git ls-remote --heads origin | grep "refs/heads/release-${{ github.event.inputs.package }}@*"; then
+            echo "::error ::Release branch already exists for package: \"${{ github.event.inputs.package }}\" please remove or merge branch before executing again."
+            exit 1
+          fi
+        # yamllint enable rule:line-length
+
       - name: Configure git User
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+      - name: Retrieve short commit hash
+        id: short_commit_hash
+        run: echo "short_commit_hash=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Switch to release branch
+        # yamllint disable-line rule:line-length
+        run: git switch --force-create release-${{ github.event.inputs.package }}@${{ steps.short_commit_hash.outputs.short_commit_hash }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -52,36 +69,26 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Bump version
+      - name: Bump version and create changelog
         run: |
-          npx nx release version \
+          npx nx release \
             --projects=${{ github.event.inputs.package }} \
-            --git-tag=true
+            --skip-publish
 
-      - name: Get previous tag
-        id: prev_tag
-        uses: WyriHaximus/github-action-get-previous-tag@v1
-
-      - name: Extract version from tag
-        id: extract_version
+      - name: Push changes
         # yamllint disable-line rule:line-length
-        run: echo "version=$(echo ${{ steps.prev_tag.outputs.tag }} | grep -oP '\d+\.\d+\.\d+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?')" >> "$GITHUB_OUTPUT"
-
-      - name: Create changelog
-        run: |
-          npx nx release changelog ${{ steps.extract_version.outputs.version }} \
-            --projects=${{ github.event.inputs.package }} \
-            --git-commit-message="chore(release): {projectName}-{version}" \
-            --git-tag=false
+        run: git push origin release-${{ github.event.inputs.package }}@${{ steps.short_commit_hash.outputs.short_commit_hash }}
 
       - name: Create pull request
-        id: create_pull_request
-        uses: peter-evans/create-pull-request@v6
-        with:
-          branch: release/${{ github.event.inputs.package }}@${{ steps.extract_version.outputs.version }}
-          delete-branch: true
-          title: Release ${{ github.event.inputs.package }}@${{ steps.extract_version.outputs.version }}
-          body: |
-            This is an automated pull request to create a new release of the package ${{ github.event.inputs.package }}.
-          reviewers: ${{ github.actor }}
-          labels: release
+        # yamllint disable rule:line-length
+        run: |
+          gh pr create \
+            --base main \
+            --body "This is an automated pull request to create a new release of the package ${{ github.event.inputs.package }}." \
+            --head release-${{ github.event.inputs.package }}@${{ steps.short_commit_hash.outputs.short_commit_hash }} \
+            --label release \
+            --reviewer ${{ github.actor }} \
+            --title "Release ${{ github.event.inputs.package }}"
+        # yamllint enable rule:line-length
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/nx.json
+++ b/nx.json
@@ -7,7 +7,10 @@
     },
     "projectsRelationship": "independent",
     "version": {
-      "conventionalCommits": true
+      "conventionalCommits": true,
+      "generatorOptions": {
+        "skipLockFileUpdate": true
+      }
     },
     "releaseTagPattern": "{projectName}-{version}"
   },

--- a/nx.json
+++ b/nx.json
@@ -6,6 +6,9 @@
       "projectChangelogs": true
     },
     "projectsRelationship": "independent",
+    "git": {
+      "commitMessage": "chore(release): {projectName}-{version}"
+    },
     "version": {
       "conventionalCommits": true,
       "generatorOptions": {


### PR DESCRIPTION
This pull request will change the behavior of how a package will be released.

How a version bump, changelog creation, package tagging, and publishing happened has been simplified. The dependencies on external actions could be reduced and replaced with built-in functionalities from GitHub CLI.

The workflow wich has the task to create a GitHub release whenever a package has been released, published, and tagged has been changed to be executed whenever the workflow "Create Tag and Publish Package" has been completed and succeeded as well. This change was required since changes made by GitHub users `dependabot[bot]` and `github-actions[bot]` won't trigger other actions, so the pushed tag did not trigger the original workflow as expected.