### PR TITLE
N8N-11 ensure package will be published

### DIFF
--- a/.github/workflows/publish-package.yaml
+++ b/.github/workflows/publish-package.yaml
@@ -51,7 +51,10 @@ jobs:
         run: npm ci
 
       - name: Create tag and publish package
-        run: npx nx release --projects=${{ steps.extract_package.outputs.package }}
+        run: |
+          npx nx release \
+            --projects=${{ steps.extract_package.outputs.package }} \
+            --yes
 
       - name: Push tags
         run: git push origin --follow-tags

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,2 +1,3 @@
 /dist
 /node_modules
+/nodes/*/CHANGELOG.md


### PR DESCRIPTION
This pull request will add an option to tell nx to publish a package, by default a prompt will be made which will be denied in a non-interactive shell, the added option tells nx to assume a yes in a non-interactive shell.