### PR TITLE
N8N-15 Don't lint commits or YAML when pull request has been edited

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -4,7 +4,6 @@ on:
   pull_request:
     types:
       - opened
-      - edited
       - reopened
       - synchronize
 


### PR DESCRIPTION
This pull request will disable the commit and YAML lint for pull requests that have only been edited and whose actual contents have not been changed.