### PR TITLE
N8N-15 Remove header pattern from commitlint configuration

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -5,7 +5,6 @@ export default {
   },
   parserPreset: {
     parserOpts: {
-      headerPattern: /^(\w*)(?:\(([\w\$\.\-\* ]*)\))?\: (.*) \(N8N-[0-9]+\)$/,
       issuePrefixes: ['N8N-'],
     },
   },


### PR DESCRIPTION
This pull request will remove the custom header pattern configuration for commitlint to fall back to its default one, as it was a bit too harsh and confusing more than it helps. Commitlint still requires a reference to be present in the commit header.