### PR TITLE
N8N-18: ensure nx release will publish the build output of a custom node

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -42,6 +42,11 @@
       "cache": true,
       "dependsOn": ["^build"],
       "inputs": ["default", "^default"]
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/nodes/{projectName}"
+      }
     }
   }
 }


### PR DESCRIPTION
This pull request will ensure that the nx release and publish process will publish the build result of the custom nodes instead of the source.