### PR TITLE
N8N-15 only cancel code check for matching pull requests

### DIFF
--- a/.github/workflows/dependabot-pull-request-enhancer.yaml
+++ b/.github/workflows/dependabot-pull-request-enhancer.yaml
@@ -12,6 +12,8 @@ jobs:
   cancel-code-check:
     name: Cancel Code Check
     runs-on: ubuntu-latest
+    # yamllint disable-line rule:line-length
+    if: github.actor == 'dependabot[bot]' && (contains(github.event.pull_request.title, 'Bump nx') || contains(github.event.pull_request.title, 'Bump n8n'))
     permissions:
       actions: write
       contents: read


### PR DESCRIPTION
This pull request will add a condition for canceling a code check on a pull requests to ensure that this will only happened for updates of n8n and nx from dependabot.