### PR TITLE
N8N-21 Disable yaml line length rule for workflow files

### DIFF
--- a/.github/workflows/create-github-release.yaml
+++ b/.github/workflows/create-github-release.yaml
@@ -66,11 +66,9 @@ jobs:
         run: pnpm exec nx build --project ${{ steps.extract_package.outputs.package }}
 
       - name: Zip package
-        # yamllint disable-line rule:line-length
         run: zip -9 -r -q ${{ steps.extract_package.outputs.package }}-${{ steps.extract_version.outputs.version }}.zip dist/nodes/${{ steps.extract_package.outputs.package }}/
 
       - name: Tar package
-        # yamllint disable-line rule:line-length
         run: tar --create --file ${{ steps.extract_package.outputs.package }}-${{steps.extract_version.outputs.version }}.tar.gz --gzip dist/nodes/${{ steps.extract_package.outputs.package }}/
 
       - name: Create GitHub release

--- a/.github/workflows/dependabot-pull-request-enhancer.yaml
+++ b/.github/workflows/dependabot-pull-request-enhancer.yaml
@@ -12,7 +12,6 @@ jobs:
   cancel-code-check:
     name: Cancel Code Check
     runs-on: ubuntu-latest
-    # yamllint disable-line rule:line-length
     if: github.actor == 'dependabot[bot]' && (contains(github.event.pull_request.title, 'Bump nx') || contains(github.event.pull_request.title, 'Bump n8n'))
     permissions:
       actions: write
@@ -23,7 +22,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Cancel Code Check
-        # yamllint disable rule:line-length
         run: |
           set -e
 
@@ -34,7 +32,6 @@ jobs:
           else
             echo "No matching run found to cancel."
           fi
-        # yamllint enable rule:line-length
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -61,7 +58,6 @@ jobs:
     uses: ./.github/workflows/code-check.yaml
     with:
       pull_request_ref: ${{ github.event.pull_request.head.ref }}
-    # yamllint disable-line rule:line-length
     if: always() && (needs.trigger-nx-dependency-update-workflow.result == 'success' || needs.trigger-n8n-dependency-update-workflow.result == 'success')
     needs:
       - trigger-nx-dependency-update-workflow

--- a/.github/workflows/n8n-dependency-update.yaml
+++ b/.github/workflows/n8n-dependency-update.yaml
@@ -32,7 +32,6 @@ jobs:
 
       - name: Retrieve target versions
         id: target-versions
-        # yamllint disable rule:line-length
         run: |
           set -e
           n8n_version=$(pnpm list n8n --filter @skriptfabrik/n8n-nodes --json | jq --raw-output --exit-status '.[0].devDependencies.n8n.version')
@@ -40,27 +39,22 @@ jobs:
           node_types_version=$(pnpm show @types/node versions --json | jq --raw-output --arg node_version "${node_version}" 'map(select(. <= $node_version)) | map(split(".") | map(tonumber)) | max_by(.) | join(".")')
           echo "node_version=${node_version}" >> "$GITHUB_OUTPUT"
           echo "node_types_version=${node_types_version}" >> "$GITHUB_OUTPUT"
-        # yamllint enable rule:line-length
 
       - name: Update node version in package.json
-        # yamllint disable-line rule:line-length
         run: yq --inplace --exit-status '.engines.node = "${{steps.target-versions.outputs.node_version}}"' package.json
 
       - name: Commit node version update in package.json
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          # yamllint disable-line rule:line-length
           commit_message: 'chore: bump node version in package.json to ${{steps.target-versions.outputs.node_version}}'
           commit_options: '--signoff'
 
       - name: Update node version in devcontainer.json
-        # yamllint disable-line rule:line-length
         run: yq --inplace --exit-status '.features."ghcr.io/devcontainers/features/node:1".version = "${{steps.target-versions.outputs.node_version}}"' .devcontainer/devcontainer.json
 
       - name: Commit node version update in devcontainer.json
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          # yamllint disable-line rule:line-length
           commit_message: 'chore: bump node version in devcontainer to ${{steps.target-versions.outputs.node_version}}'
           commit_options: '--signoff'
 
@@ -73,7 +67,6 @@ jobs:
       - name: Commit @types/node update
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          # yamllint disable-line rule:line-length
           commit_message: 'chore: bump @types/node version to ${{ steps.target-versions.outputs.node_types_version }}'
           commit_options: '--signoff'
 
@@ -102,44 +95,36 @@ jobs:
 
       - name: Retrieve target versions
         id: target-versions
-        # yamllint disable rule:line-length
         run: |
           set -e
           n8n_nodes_base_version=$(npm list n8n-nodes-base --json --depth 1 | jq --raw-output --exit-status '.dependencies.n8n.dependencies."n8n-nodes-base".version')
           n8n_workflow_version=$(npm list n8n-workflow --json --depth 1 | jq --raw-output --exit-status '.dependencies.n8n.dependencies."n8n-workflow".version')
           echo "n8n_nodes_base_version=${n8n_nodes_base_version}" >> "$GITHUB_OUTPUT"
           echo "n8n_workflow_version=${n8n_workflow_version}" >> "$GITHUB_OUTPUT"
-        # yamllint enable rule:line-length
 
       - name: Update n8n-nodes-base
-        # yamllint disable rule:line-length
         run: |
           pnpm add n8n-nodes-base@${{ steps.target-versions.outputs.n8n_nodes_base_version }} \
             --ignore-workspace-root-check \
             --save-dev \
             --save-exact
-        # yamllint enable rule:line-length
 
       - name: Commit n8n-nodes-base update
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          # yamllint disable-line rule:line-length
           commit_message: 'chore: bump n8n-nodes-base version to ${{ steps.target-versions.outputs.n8n_nodes_base_version }}'
           commit_options: '--signoff'
 
       - name: Update n8n-workflow
-        # yamllint disable rule:line-length
         run: |
           pnpm add n8n-workflow@${{ steps.target-versions.outputs.n8n_workflow_version }} \
             --ignore-workspace-root-check \
             --save-dev \
             --save-exact
-        # yamllint enable rule:line-length
 
       - name: Commit n8n-workflow update
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          # yamllint disable-line rule:line-length
           commit_message: 'chore: bump n8n-workflow version to ${{ steps.target-versions.outputs.n8n_workflow_version }}'
           commit_options: '--signoff'
 
@@ -193,39 +178,31 @@ jobs:
 
       - name: Retrieve target versions
         id: target-versions
-        # yamllint disable rule:line-length
         run: |
           set -e
           n8n_nodes_base_version=$(npm list n8n-nodes-base --json --depth 1 | jq --raw-output --exit-status '.dependencies.n8n.dependencies."n8n-nodes-base".version')
           n8n_workflow_version=$(npm list n8n-workflow --json --depth 1 | jq --raw-output --exit-status '.dependencies.n8n.dependencies."n8n-workflow".version')
           echo "n8n_nodes_base_version=${n8n_nodes_base_version}" >> "$GITHUB_OUTPUT"
           echo "n8n_workflow_version=${n8n_workflow_version}" >> "$GITHUB_OUTPUT"
-        # yamllint enable rule:line-length
 
       - name: Update n8n-nodes-base version
-        # yamllint disable rule:line-length
         run: |
           yq --inplace --exit-status '(select(.peerDependencies.n8n-nodes-base) | .peerDependencies.n8n-nodes-base) = "${{ steps.target-versions.outputs.n8n_nodes_base_version }}"' ${{ matrix.package.json }}
           pnpm install --no-frozen-lockfile
-        # yamllint enable rule:line-length
 
       - name: Commit n8n-nodes-base version update
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          # yamllint disable-line rule:line-length
           commit_message: 'fix(${{matrix.package.name}}): bump n8n-nodes-base version to ${{ steps.target-versions.outputs.n8n_nodes_base_version }}'
           commit_options: '--signoff'
 
       - name: Update n8n-workflow version
-        # yamllint disable rule:line-length
         run: |
           yq --inplace --exit-status '(select(.peerDependencies.n8n-workflow) | .peerDependencies.n8n-workflow) = "${{ steps.target-versions.outputs.n8n_workflow_version }}"' ${{ matrix.package.json }}
           pnpm install --no-frozen-lockfile
-        # yamllint enable rule:line-length
 
       - name: Commit n8n-workflow version update
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          # yamllint disable-line rule:line-length
           commit_message: 'fix(${{matrix.package.name}}): bump n8n-workflow version to ${{ steps.target-versions.outputs.n8n_workflow_version }}'
           commit_options: '--signoff'

--- a/.github/workflows/nx-dependency-update.yaml
+++ b/.github/workflows/nx-dependency-update.yaml
@@ -48,7 +48,6 @@ jobs:
       - name: Commit changes to package(-lock).json
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          # yamllint disable-line rule:line-length
           commit_message: 'chore: bump nx dependencies to ${{ steps.dependabot-metadata.outputs.new-version }}'
           commit_options: '--signoff'
           file_pattern: 'package.json pnpm-lock.yaml'

--- a/.github/workflows/publish-package.yaml
+++ b/.github/workflows/publish-package.yaml
@@ -22,7 +22,6 @@ jobs:
     steps:
       - name: Extract package from head ref
         id: extract_package
-        # yamllint disable-line rule:line-length
         run: echo "package=$(echo ${{ github.event.pull_request.head.ref }} | sed -E 's/release-(.*)@.*/\1/')" >> "$GITHUB_OUTPUT"
 
       - name: Checkout

--- a/.github/workflows/release-package.yaml
+++ b/.github/workflows/release-package.yaml
@@ -36,13 +36,11 @@ jobs:
           fetch-tags: true
 
       - name: Check on existing release branch
-        # yamllint disable rule:line-length
         run: |
           if git ls-remote --heads origin | grep "refs/heads/release-${{ github.event.inputs.package }}@*"; then
             echo "::error ::Release branch already exists for package: \"${{ github.event.inputs.package }}\" please remove or merge branch before executing again."
             exit 1
           fi
-        # yamllint enable rule:line-length
 
       - name: Setup git user
         uses: fregante/setup-git-user@v2
@@ -52,7 +50,6 @@ jobs:
         run: echo "short_commit_hash=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Switch to release branch
-        # yamllint disable-line rule:line-length
         run: git switch --force-create release-${{ github.event.inputs.package }}@${{ steps.short_commit_hash.outputs.short_commit_hash }}
 
       - name: Setup pnpm
@@ -74,11 +71,9 @@ jobs:
             --skip-publish
 
       - name: Push changes
-        # yamllint disable-line rule:line-length
         run: git push origin release-${{ github.event.inputs.package }}@${{ steps.short_commit_hash.outputs.short_commit_hash }}
 
       - name: Create pull request
-        # yamllint disable rule:line-length
         run: |
           gh pr create \
             --base main \
@@ -87,6 +82,5 @@ jobs:
             --label release \
             --reviewer ${{ github.actor }} \
             --title "Release ${{ github.event.inputs.package }}"
-        # yamllint enable rule:line-length
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -9,6 +9,8 @@ rules:
   document-start: false
   line-length:
     max: 120
+    ignore:
+      - /.github/workflows/*.yaml
   new-lines:
     type: unix
   new-line-at-end-of-file:


### PR DESCRIPTION
This pull request will disable the line-length rule in Yamllint for all GitHub Workflow files as it's often hard and unpracticable to maintain the requested limit, leading to repeated comments to disable it.

Attention: this pr is based on https://github.com/skriptfabrik/n8n-nodes/pull/218 to avoid conflicts and leftovers after the merge.