### PR TITLE
N8N-22 Add ability to provide impersonation information on activity update

### DIFF
--- a/nodes/moco/src/nodes/Moco/ActivityDescription.ts
+++ b/nodes/moco/src/nodes/Moco/ActivityDescription.ts
@@ -433,6 +433,23 @@ export const activityFields: INodeProperties[] = [
   /*                                 activity:update                            */
   /* -------------------------------------------------------------------------- */
   {
+    displayName: 'Impersonate User Name or ID',
+    name: 'impersonateUserId',
+    type: 'options',
+    default: '',
+    typeOptions: {
+      loadOptionsMethod: 'listUsers',
+    },
+    description:
+      'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>',
+    displayOptions: {
+      show: {
+        resource: ['activity'],
+        operation: ['update'],
+      },
+    },
+  },
+  {
     displayName: 'Activity ID',
     name: 'activityId',
     type: 'string',

--- a/nodes/moco/src/nodes/Moco/Moco.node.spec.ts
+++ b/nodes/moco/src/nodes/Moco/Moco.node.spec.ts
@@ -458,6 +458,9 @@ describe('Moco', () => {
       0,
       'DELETE',
       `/activities/${activityId}`,
+      {
+        impersonateUserId: undefined,
+      },
     );
   });
 

--- a/nodes/moco/src/nodes/Moco/Moco.node.spec.ts
+++ b/nodes/moco/src/nodes/Moco/Moco.node.spec.ts
@@ -770,7 +770,10 @@ describe('Moco', () => {
       0,
       'PUT',
       `/activities/${activityId}`,
-      { body },
+      {
+        impersonateUserId: undefined,
+        body,
+      },
     );
   });
 

--- a/nodes/moco/src/nodes/Moco/Moco.node.ts
+++ b/nodes/moco/src/nodes/Moco/Moco.node.ts
@@ -379,6 +379,10 @@ export class Moco implements INodeType {
           if (operation === 'update') {
             const activityId = this.getNodeParameter('activityId', item);
 
+            const impersonateUserId =
+              (this.getNodeParameter('impersonateUserId', item) as string) ||
+              undefined;
+
             const body: ActivityParameters = {
               date: this.getNodeParameter('date', item) as string,
               project_id: this.getNodeParameter('projectId', item) as number,
@@ -398,7 +402,7 @@ export class Moco implements INodeType {
               item,
               'PUT',
               `/activities/${activityId}`,
-              { body },
+              { impersonateUserId, body },
             )) as User;
           }
         }

--- a/nodes/moco/src/nodes/Moco/Moco.node.ts
+++ b/nodes/moco/src/nodes/Moco/Moco.node.ts
@@ -312,11 +312,16 @@ export class Moco implements INodeType {
           if (operation === 'delete') {
             const activityId = this.getNodeParameter('activityId', item);
 
+            const impersonateUserId =
+              (this.getNodeParameter('impersonateUserId', item) as string) ||
+              undefined;
+
             responseData = (await mocoApiRequest.call(
               this,
               item,
               'DELETE',
               `/activities/${activityId}`,
+              { impersonateUserId },
             )) as never;
           }
 


### PR DESCRIPTION
This pull request will add the ability to provide impersonation information for MOCO activity updates.

The usage of the impersonation information for updating activities using a "global" API key has been required since Aug 22, 2024.

It will also prepare the ability to provide impersonation information for MOCO activity deletes, which is currently not required but will be added soon.