### PR TITLE
ci: allow manual workflow dispatch for a n8n dependency update (N8N-25)

### DIFF
--- a/.github/workflows/n8n-dependency-update.yaml
+++ b/.github/workflows/n8n-dependency-update.yaml
@@ -1,6 +1,11 @@
 name: n8n Dependency Update
 
 on:
+  workflow_dispatch:
+    inputs:
+      pull_request_ref:
+        required: true
+        type: string
   workflow_call:
     inputs:
       pull_request_ref:


### PR DESCRIPTION
This pull request will allow to manually trigger a n8n dependency update based on an existing pull request.

This will allow to provide a pull request wich only updates n8n to a specific version and the dispatched workflow will do the heavy lifting.

This is required since n8n tags its packages with versions which they describe themself as beta and dependabot cannot know if the available version is stable or not.