### PR TITLE
chore: drop deprecated eslint__js types dependency (N8N-6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "@swc-node/register": "1.9.2",
     "@swc/core": "1.11.24",
     "@swc/helpers": "0.5.17",
-    "@types/eslint__js": "^9.14.0",
     "@types/express": "4.17.21",
     "@types/jest": "29.5.12",
     "@types/jsonwebtoken": "^9.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,9 +60,6 @@ importers:
       '@swc/helpers':
         specifier: 0.5.17
         version: 0.5.17
-      '@types/eslint__js':
-        specifier: ^9.14.0
-        version: 9.14.0
       '@types/express':
         specifier: 4.17.21
         version: 4.17.21
@@ -3627,10 +3624,6 @@ packages:
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
-
-  '@types/eslint__js@9.14.0':
-    resolution: {integrity: sha512-s0jepCjOJWB/GKcuba4jISaVpBudw3ClXJ3fUK4tugChUMQsp6kSwuA8Dcx6wFd/JsJqcY8n4rEpa5RTHs5ypA==}
-    deprecated: This is a stub types definition. @eslint/js provides its own type definitions, so you do not need this installed.
 
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
@@ -14840,10 +14833,6 @@ snapshots:
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
-
-  '@types/eslint__js@9.14.0':
-    dependencies:
-      '@eslint/js': 9.25.1
 
   '@types/estree@1.0.7': {}
 


### PR DESCRIPTION
This pull request will drop the deprecated dependency containing types for eslint__js that are now served through @eslint/js itself.