### PR TITLE
chore: replace GitHub dependabot reviewers with codeowners (INTERN-68)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,5 @@
-# Codeowners
-/.github/CODEOWNERS   @owner_username
-
-# GitHub Actions workflow files
-/.github/workflows/   @skriptfabrik/github-actions-maintainers
+# GitHub Actions files
+/.github/             @skriptfabrik/github-actions-maintainers
 
 # Devcontainer configuration
 /.devcontainer/       @skriptfabrik/devcontainer-maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# Codeowners
+/.github/CODEOWNERS   @owner_username
+
+# GitHub Actions workflow files
+/.github/workflows/   @skriptfabrik/github-actions-maintainers
+
+# Devcontainer configuration
+/.devcontainer/       @skriptfabrik/devcontainer-maintainers
+
+# NPM package files
+package.json          @skriptfabrik/npm-maintainers
+pnpm-lock.yaml        @skriptfabrik/npm-maintainers

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,8 +3,6 @@ version: 2
 updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
-    reviewers:
-      - 'skriptfabrik/github-actions-maintainers'
     schedule:
       interval: 'weekly'
     commit-message:
@@ -12,8 +10,6 @@ updates:
 
   - package-ecosystem: 'devcontainers'
     directory: '/'
-    reviewers:
-      - 'skriptfabrik/devcontainer-maintainers'
     schedule:
       interval: 'weekly'
     commit-message:
@@ -26,8 +22,6 @@ updates:
       - dependency-name: '@types/*'
       - dependency-name: 'n8n-nodes-base'
       - dependency-name: 'n8n-workflow'
-    reviewers:
-      - 'skriptfabrik/npm-maintainers'
     schedule:
       interval: 'weekly'
     commit-message:

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -15,7 +15,7 @@ export default {
   ],
   parserPreset: {
     parserOpts: {
-      issuePrefixes: ['N8N-'],
+      issuePrefixes: ['INTERN-', 'N8N-'],
     },
   },
 };


### PR DESCRIPTION
This pull request will replace the retiring dependabot reviewers configuration with CODEOWNERS.

@schroedan Please have a look at the configuration about protecting the CODEOWNERS file itself, I followed the recommendations [here](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-and-branch-protection), you might have a different opinion in the direction of a team instead the repository owner.