### PR TITLE
chore: bump pnpm from 10.15.1 to 10.20.0 (N8N-6)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
   "features": {
     "ghcr.io/devcontainers/features/node:1": {
       "version": "22.18.0",
-      "pnpmVersion": "10.15.1",
+      "pnpmVersion": "10.20.0",
       "nodeGypDependencies": true
     },
     "ghcr.io/devcontainers-extra/features/markdownlint-cli:1": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "engines": {
     "node": "22.18.0",
-    "pnpm": "^10.15.1"
+    "pnpm": "^10.20.0"
   },
   "devEngines": {
     "runtime": {
@@ -84,7 +84,7 @@
     },
     "packageManager": {
       "name": "pnpm",
-      "version": "^10.15.1",
+      "version": "^10.20.0",
       "onFail": "warn"
     }
   },
@@ -101,5 +101,5 @@
       }
     }
   },
-  "packageManager": "pnpm@10.15.1"
+  "packageManager": "pnpm@10.20.0"
 }


### PR DESCRIPTION
This pull request will bump pnpm from version 10.15.1 to 10.20.0.