### PR TITLE
fix(moco): hide deals fields if not needed (#1079)

### DIFF
--- a/packages/moco/nodes/Moco/Descriptions/DealDescription.ts
+++ b/packages/moco/nodes/Moco/Descriptions/DealDescription.ts
@@ -104,6 +104,12 @@ export const dealFields: INodeProperties[] = [
     required: true,
     default: '',
     description: 'Reminder date of the deal',
+    displayOptions: {
+      show: {
+        resource: ['deals'],
+        operation: ['create'],
+      },
+    },
   },
   {
     displayName: 'User Name or ID',
@@ -111,6 +117,12 @@ export const dealFields: INodeProperties[] = [
     type: 'options',
     typeOptions: {
       loadOptionsMethod: 'listUsers',
+    },
+    displayOptions: {
+      show: {
+        resource: ['deals'],
+        operation: ['create'],
+      },
     },
     default: '',
     description:
@@ -124,6 +136,12 @@ export const dealFields: INodeProperties[] = [
     type: 'options',
     typeOptions: {
       loadOptionsMethod: 'listDealCategories',
+    },
+    displayOptions: {
+      show: {
+        resource: ['deals'],
+        operation: ['create'],
+      },
     },
     default: '',
     description:

--- a/packages/moco/nodes/Moco/Moco.node.ts
+++ b/packages/moco/nodes/Moco/Moco.node.ts
@@ -99,6 +99,10 @@ export class Moco implements INodeType {
             value: 'contacts',
           },
           {
+            name: 'Deal',
+            value: 'deals',
+          },
+          {
             name: 'Project',
             value: 'project',
           },


### PR DESCRIPTION
Addresses issue #1079 
- fixes deals resource not shown
- fixes deals properties shown if not needed